### PR TITLE
Adding message to run/rerun, other interface tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.2.x](https://github.com/vsoch/qme/tree/master) (0.0.x)
+ - small updates to interface and nitpicks (0.0.11)
  - first release with basic dashboard and databases (0.0.1)
  - skeleton release (0.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,6 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.2.x](https://github.com/vsoch/qme/tree/master) (0.0.x)
- - small updates to interface and nitpicks (0.0.11)
+ - adding message argument to run/re-run, print of host/port to start (0.0.11)
  - first release with basic dashboard and databases (0.0.1)
  - skeleton release (0.0.0)

--- a/docs/_docs/getting-started/commands.md
+++ b/docs/_docs/getting-started/commands.md
@@ -30,6 +30,12 @@ DATABASE: filesystem
 The command is so quick that it gives you the result immediately. In the above,
 we see the executor (shell) along with the unique id (the following uuid), 
 and the full command (to list the expanded $PWD) and the return code 0. 
+If you want to add a message (annotation) to store with the task and be used
+for search, add `-m/--message` to your run:
+
+```bash
+qme -m "This is a listing for the thing" run ls $PWD
+```
 
 There is one special case, the argument --help, which if run without
 thinking, will be parsed by the client and print the get help:
@@ -261,6 +267,15 @@ You can also rerun the last touched task without needing to specify the identifi
 ```bash
 $ qme rerun
 ```
+
+And akin to run, if you want to add a message (to update the existing) you can
+do that too:
+
+
+```bash
+qme -m "This is a listing for the thing" rerun
+```
+
 
 <a id="search">
 ## Search

--- a/qme/app/server.py
+++ b/qme/app/server.py
@@ -40,7 +40,7 @@ def start(port=5000, debug=True, queue=None, host=None):
        the hostname, set the environment variable QME_HOSTNAME or set on command
        line with qme start.
     """
-    bot.info(f"QueueMe: running on http://localhost:{port}")
+    bot.info(f"QueueMe: running on http://{host}:{port}")
 
     # If the user doesn't specify a queue, use default
     if not queue:

--- a/qme/app/server.py
+++ b/qme/app/server.py
@@ -10,6 +10,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from flask_socketio import SocketIO
 from flask import Flask
+
 from qme.logger import bot
 from qme.defaults import QME_HOSTNAME
 
@@ -39,7 +40,7 @@ def start(port=5000, debug=True, queue=None, host=None):
        the hostname, set the environment variable QME_HOSTNAME or set on command
        line with qme start.
     """
-    bot.info("QueueMe!")
+    bot.info(f"QueueMe: running on http://localhost:{port}")
 
     # If the user doesn't specify a queue, use default
     if not queue:

--- a/qme/app/server.py
+++ b/qme/app/server.py
@@ -40,6 +40,7 @@ def start(port=5000, debug=True, queue=None, host=None):
        the hostname, set the environment variable QME_HOSTNAME or set on command
        line with qme start.
     """
+    host = host or QME_HOSTNAME
     bot.info(f"QueueMe: running on http://{host}:{port}")
 
     # If the user doesn't specify a queue, use default
@@ -59,7 +60,7 @@ def start(port=5000, debug=True, queue=None, host=None):
 
     # Add the queue to the server
     app.queue = queue
-    socketio.run(app, port=port, debug=debug, host=host or QME_HOSTNAME)
+    socketio.run(app, port=port, debug=debug, host=host)
 
 
 # This is how the command line version will run

--- a/qme/app/templates/executors/shell.html
+++ b/qme/app/templates/executors/shell.html
@@ -48,6 +48,10 @@
 				<td>Return Code</td>
 				<td>{{ task.data.returncode }}</td>
 			      </tr>
+			      {% if task.data.message %}<tr>
+				<td>Annotation</td>
+				<td>{{ task.data.message }}</td>
+			      </tr>{% endif %}
 			      <tr>
 				<td>Status</td>
 				<td>{{ task.data.status }}</td>

--- a/qme/client/__init__.py
+++ b/qme/client/__init__.py
@@ -33,6 +33,13 @@ def get_parser():
         help="select database and configuration directory (defaults to $HOME/.qme).",
     )
 
+    parser.add_argument(
+        "-m",
+        "--message",
+        dest="message",
+        help="Add a message or description to store alongside a run.",
+    )
+
     description = "actions for qme"
     subparsers = parser.add_subparsers(
         help="qme actions", title="actions", description=description, dest="command",

--- a/qme/client/run.py
+++ b/qme/client/run.py
@@ -32,11 +32,11 @@ def run(args, extra):
             command += shlex.split(item)
 
     # Extra might include unparsed arguments
-    queue.run(command + extra)
+    queue.run(command=command + extra, message=args.message)
 
 
 def rerun(args, extra):
 
     # Create a queue object, run the command to match to an executor
     queue = Queue(config_dir=args.config_dir)
-    queue.rerun(args.taskid)
+    queue.rerun(taskid=args.taskid, message=args.message)

--- a/qme/logger/message.py
+++ b/qme/logger/message.py
@@ -322,7 +322,7 @@ def get_logging_level():
         MESSAGELEVEL. if MESSAGELEVEL is not set, the maximum level
         (5) is assumed (all messages).
     """
-    level = os.environ.get("MESSAGELEVEL", INFO)
+    level = os.environ.get("QME_MESSAGELEVEL", INFO)
 
     # User knows logging levels and set one
     if isinstance(level, int):

--- a/qme/main/__init__.py
+++ b/qme/main/__init__.py
@@ -108,7 +108,7 @@ class Queue:
         else:
             sys.exit(f"Unrecognized target to clear {target}")
 
-    def run(self, command):
+    def run(self, command, message=None):
         """Given a command, get the executor for it (also creating an entry
            in the task database) and run the command.
         """
@@ -118,12 +118,12 @@ class Queue:
         task = self.db.add_task(executor)
 
         # Execute and store result (this will need to be generalized)
-        task.executor.execute()
+        task.executor.execute(message=message)
         self.db.update_task(task.executor)
         bot.info(f"{task.summary()}")
         return task
 
-    def rerun(self, taskid=None):
+    def rerun(self, taskid=None, message=None):
         """Given a command, get the executor for it (also creating an entry
            in the task database) and run the command. If the task is found and
            rerun, it is returned. Otherwise None is returned.
@@ -135,7 +135,7 @@ class Queue:
         if pwd:
             os.chdir(pwd)
         if command:
-            task.executor.execute(command)
+            task.executor.execute(command, message=message)
             self.db.update_task(task.executor)
             bot.info(f"{task.summary()}")
             return task

--- a/qme/main/database/filesystem.py
+++ b/qme/main/database/filesystem.py
@@ -22,6 +22,7 @@ from glob import glob
 import shutil
 import uuid
 import os
+import re
 import sys
 
 
@@ -182,9 +183,23 @@ class FileSystemTask:
         """
         if should_exist:
             if not os.path.exists(self.filename):
-                bot.exit(
-                    f"{self.executor.taskid} does not exist in the filesystem database"
+
+                # Might be provided prefix
+                contenders = glob(
+                    "%s*" % os.path.join(self.executor_dir, self.executor.taskid)
                 )
+                if len(contenders) == 1:
+                    self.executor.taskid = re.sub(
+                        "(%s/|[.]json)"
+                        % os.path.join(self.data_base, self.executor.name),
+                        "",
+                        contenders[0],
+                    )
+
+                elif len(contenders) > 1:
+                    sys.exit(f"More than one task found for {self.executor.taskid}")
+                else:
+                    sys.exit(f"Cannot find task {self.executor.taskid}")
             self.data = self.load()
 
         if not os.path.exists(self.executor_dir):

--- a/qme/main/database/relational.py
+++ b/qme/main/database/relational.py
@@ -114,8 +114,7 @@ class RelationalDatabase(Database):
 
     def get_task(self, taskid=None):
         """Get a task based on a taskid. Exits on error if doesn't exist. If
-           a task id is not provided, get the last run task. Unlike the filesystem
-           database, this get_task supports getting a partial task id.
+           a task id is not provided, get the last run task.
         """
         from qme.main.database.models import Task
 

--- a/qme/main/executor/base.py
+++ b/qme/main/executor/base.py
@@ -96,6 +96,7 @@ class ExecutorBase:
             _, uid = taskid.split("-", 1)
         self.taskid = "%s-%s" % (self.name, uid)
         self.pwd = os.getcwd()
+        self.message = None
         self.actions = {}
         if not hasattr(self, "data"):
             self.data = {}
@@ -105,11 +106,14 @@ class ExecutorBase:
            and timestamp for when it was run. This might include envars at some
            point, but we'd need to be careful.
         """
-        return {
+        common = {
             "pwd": self.pwd,
             "user": get_user(),
             "timestamp": str(datetime.now()),
         }
+        if self.message:
+            common["message"] = self.message
+        return common
 
     def export(self):
         """return data as json. This is intended to save to the task database.
@@ -194,7 +198,7 @@ class ExecutorBase:
     def summary(self):
         return "[%s]" % self.name
 
-    def execute(self, cmd=None):
+    def execute(self, cmd=None, message=None):
         raise NotImplementedError
 
     def get_output(self):

--- a/qme/main/executor/shell.py
+++ b/qme/main/executor/shell.py
@@ -61,7 +61,7 @@ class ShellExecutor(ExecutorBase):
             cmd = shlex.split(cmd)
         self.data["cmd"] = cmd
 
-    def execute(self, cmd=None):
+    def execute(self, cmd=None, message=None):
         """Execute a system command and return output and error. Execute
            should take a cmd (a string or list) and execute it according to
            the executor. Attributes should be set on the class that are
@@ -69,6 +69,7 @@ class ShellExecutor(ExecutorBase):
            by most executors, we create a self._execute() class that is called
            instead, and can be used by the other executors.
         """
+        self.message = message
         return self._execute(cmd)
 
     def _execute(self, cmd=None):

--- a/qme/main/executor/slurm.py
+++ b/qme/main/executor/slurm.py
@@ -34,7 +34,7 @@ class SlurmExecutor(ShellExecutor):
             "cancel": self.action_cancel,
         }
 
-    def execute(self, cmd=None):
+    def execute(self, cmd=None, message=None):
         """Execute a system command and return output and error. Execute
            should take a cmd (a string or list) and execute it according to
            the executor. Attributes should be set on the class that are
@@ -42,6 +42,7 @@ class SlurmExecutor(ShellExecutor):
            by most executors, we create a self._execute() class that is called
            instead, and can be used by the other executors.
         """
+        self.message = message
         self._execute(cmd)
         if self.data["returncode"] == 0:
 

--- a/qme/utils/file.py
+++ b/qme/utils/file.py
@@ -99,7 +99,7 @@ def get_userhome():
 
         return pwd.getpwuid(os.getuid())[5]
     except:
-        return os.environ.get("HOME")
+        return os.environ.get("HOME") or os.environ.get("HOMEPATH")
 
 
 def get_user():
@@ -111,7 +111,7 @@ def get_user():
 
         return pwd.getpwuid(os.getuid())[0]
     except:
-        return os.environ.get("USER")
+        return os.environ.get("USER") or os.environ.get("USERNAME")
 
 
 def mkdir_p(path):

--- a/qme/version.py
+++ b/qme/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.1"
+__version__ = "0.0.11"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "qme"

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -46,6 +46,10 @@ def test_executors_filesystem(tmp_path):
         for key in ["pwd", "user", "timestamp"]:
             assert key in data
 
+        # Ensure a message is added, if defined with run
+        task = queue.run("ls", message="this is my custom message")
+        assert "message" in task.load()["data"]
+
 
 def test_filesystem(tmp_path):
     """Test loading and using a queue with the filesystem database.


### PR DESCRIPTION
This pull request will address the following issues:

 - #28 that will match a partial task id
 - #27 to add the ability to specify a message to run or rerun
 - #26 adding the address / port to the qme start (note this is normally there when debug is on)