### PR TITLE
Updating logger to use default python logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.2.x](https://github.com/vsoch/qme/tree/master) (0.0.x)
+ - using standard Python logging for error/other messages (0.0.12)
  - adding message argument to run/re-run, print of host/port to start (0.0.11)
  - first release with basic dashboard and databases (0.0.1)
  - skeleton release (0.0.0)

--- a/docs/_docs/getting-started/environment.md
+++ b/docs/_docs/getting-started/environment.md
@@ -61,6 +61,27 @@ Within that directory, you will see the following structure:
 If you want to change this location, then you'll need to (more permanently) export
 `QME_HOME` in your bash profile, or perhaps in a container install.
 
+### QME_LOG_LEVEL
+
+If you want to set the logging level from the environment, set `QME_LOG_LEVEL` to 
+one of "WARNING" "DEBUG" "INFO" "CRITICAL" "ERROR" or "FATAL". For example, to silence
+most all messages, we might set it to fatal:
+
+```bash
+export QME_LOG_LEVEL=FATAL
+```
+
+You can override the environment default by way of using the `--log_level` flag:
+
+```bash
+$ qme --log_level INFO get
+```
+
+If you set an environment level that is not one of the choices, it will default
+to using info. If you provide an inccorect value to `--log_level` you will be asked
+to run the command again and choose from the valid choices.
+
+
 ### QME_SOCKET_UPDATE_SECONDS
 
 If you are using the dashboard (which uses web sockets) this is the number of

--- a/docs/_docs/tutorials/create-executor.md
+++ b/docs/_docs/tutorials/create-executor.md
@@ -237,18 +237,26 @@ then be exported to the database and available to future actions.
 
 ### Logging
 
-You might find the bot logger useful for writing messages to the user:
+You can import a logger to write messages to the user:
+
+```bash
+import logging
+logger = logging.getLogger("qme.main.executor.slurm")
+
+bot.info("This is an information message in purple")
+logger.warning("This is a warning in yellow")
+logger.error("This is an error in red")
+logger.debug("This is a debug message in aqua.")
+```
+
+If you need to format a list of lists into a table, or if you need a spinner
+or other colored output, you can import the QueueMeMessage class:
 
 ```bash
 from qme.logger import bot
-
-bot.info("This is an information message in purple")
-bot.warning("This is a warning in yellow")
-bot.error("This is an error in red")
-bot.exit("This is also an error, with return code 1")
-bot.exit("This is also an error, with return code 255", return_code=255)
-bot.debug("This is a debug message in aqua.")
-bot.log("This is a log level message in purple.")
+bot.table([["1", "1", "1"],["2","2", "2"]]) 
+1  1	1	1
+2  2	2	2
 ```
 
 We don't currently have executor-specific logging files, but this can be added

--- a/qme/app/server.py
+++ b/qme/app/server.py
@@ -33,7 +33,7 @@ from qme.app.views import *
 from qme.app.api import *
 
 
-def start(port=5000, debug=True, queue=None, host=None):
+def start(port=5000, debug=True, queue=None, host=None, level="DEBUG"):
     """Start can be invoked when this file is executed (see __main__ below)
        or used as a function to programmatically start a server. If started
        via qme view, we can add the queue to the server. If you want to change
@@ -56,7 +56,7 @@ def start(port=5000, debug=True, queue=None, host=None):
     )
     file_handler.setFormatter(formatter)
     app.logger.addHandler(file_handler)
-    app.logger.setLevel(logging.DEBUG)
+    app.logger.setLevel(getattr(logging, level))
 
     # Add the queue to the server
     app.queue = queue

--- a/qme/app/views/main.py
+++ b/qme/app/views/main.py
@@ -72,7 +72,7 @@ def update_database():
 @socketio.on("deleterow", namespace="/table/action")
 def delete_row(json):
     """a request to delete a particular row"""
-    app.logger.debug("Received deletion request for %s" % json.get("taskid"))
+    app.logger.debug("Received deletion request for %s", json.get("taskid"))
     taskid = json.get("taskid", "doesnotexist")
     was_deleted = app.queue.clear(target=taskid, noprompt=True)
     socketio.emit(
@@ -86,7 +86,7 @@ def delete_row(json):
 def rerun_row(json):
     """a request to re-run a particular task.
     """
-    app.logger.debug("Received re-run request for %s" % json.get("taskid"))
+    app.logger.debug("Received re-run request for %s", json.get("taskid"))
     taskid = json.get("taskid", "doesnotexist")
     was_rerun = app.queue.rerun(taskid) is not None
     socketio.emit(

--- a/qme/client/__init__.py
+++ b/qme/client/__init__.py
@@ -10,10 +10,12 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
+from qme.logger import QME_LOG_LEVEL, QME_LOG_LEVELS
 import qme
 import argparse
 import sys
 import os
+import logging
 
 
 def get_parser():
@@ -25,6 +27,14 @@ def get_parser():
         help="suppress additional output.",
         default=False,
         action="store_true",
+    )
+
+    parser.add_argument(
+        "--log_level",
+        dest="log_level",
+        choices=QME_LOG_LEVELS,
+        default=QME_LOG_LEVEL,
+        help="Customize logging level for QueueMe.",
     )
 
     parser.add_argument(
@@ -169,6 +179,11 @@ def main():
 
     # If an error occurs while parsing the arguments, the interpreter will exit with value 2
     args, extra = parser.parse_known_args()
+
+    # Set the logging level
+    logging.basicConfig(level=getattr(logging, args.log_level))
+    bot = logging.getLogger("qme.client")
+    bot.setLevel(getattr(logging, args.log_level))
 
     # Show the version and exit
     if args.command == "version" or args.version:

--- a/qme/client/config.py
+++ b/qme/client/config.py
@@ -9,13 +9,14 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
 
 from qme.main.config import Config
-from qme.logger import bot
 import sys
 import os
 import re
 
 
 def main(args, extra):
+
+    bot = logging.getLogger("qme.client")
 
     # The user wants to set the database
     if args.database:

--- a/qme/client/start.py
+++ b/qme/client/start.py
@@ -22,7 +22,7 @@ def main(args, extra):
     try:
         from qme.app.server import start
 
-        start(port=args.port, queue=queue, debug=args.debug)
+        start(port=args.port, queue=queue, debug=args.debug, level=args.log_level)
     except:
         sys.exit(
             "You must 'pip install qme[app]' 'pip install qme[all]' to use the dashboard."

--- a/qme/defaults.py
+++ b/qme/defaults.py
@@ -8,10 +8,16 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
+from qme.logger import QME_LOG_LEVEL, QME_LOG_LEVELS
 from qme.utils.file import get_userhome
+import logging
 import multiprocessing
 import os
 import sys
+
+
+logging.basicConfig(level=getattr(logging, QME_LOG_LEVEL))
+bot = logging.getLogger("qme.defaults")
 
 
 def getenv(variable_key, default=None, required=False, silent=True):

--- a/qme/logger/__init__.py
+++ b/qme/logger/__init__.py
@@ -1,3 +1,10 @@
+import os
 from .message import bot
 from .progress import ProgressBar
 from .namer import RobotNamer
+
+# Shared logging import for both client and default.py (for headless)
+QME_LOG_LEVEL = os.environ.get("QME_LOG_LEVEL", "INFO")
+QME_LOG_LEVELS = ["DEBUG", "CRITICAL", "ERROR", "WARNING", "INFO", "QUIET", "FATAL"]
+if QME_LOG_LEVEL not in QME_LOG_LEVELS:
+    QME_LOG_LEVEL = "INFO"

--- a/qme/logger/message.py
+++ b/qme/logger/message.py
@@ -354,7 +354,7 @@ def get_logging_level():
 
 
 def get_user_color_preference():
-    COLORIZE = os.environ.get("SINGULARITY_COLORIZE", None)
+    COLORIZE = os.environ.get("QME_COLORIZE", None)
     if COLORIZE is not None:
         COLORIZE = convert2boolean(COLORIZE)
     return COLORIZE

--- a/qme/main/__init__.py
+++ b/qme/main/__init__.py
@@ -14,11 +14,13 @@ from qme.main.database import init_db
 from qme.main.executor import get_executor
 from qme.utils.regex import uuid_regex
 from qme.utils.prompt import confirm
-from qme.logger import bot
 
+import logging
 import os
 import re
 import sys
+
+bot = logging.getLogger("qme.main")
 
 
 class Queue:

--- a/qme/main/config/__init__.py
+++ b/qme/main/config/__init__.py
@@ -8,14 +8,16 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-from qme.logger import bot
 from qme.utils.file import mkdir_p, read_json, write_json
 
 import configparser
+import logging
 import os
 import shutil
 
 here = os.path.dirname(os.path.abspath(__file__))
+
+bot = logging.getLogger("qme.main.config")
 
 
 class Config:

--- a/qme/main/database/filesystem.py
+++ b/qme/main/database/filesystem.py
@@ -17,13 +17,15 @@ from qme.utils.file import (
 )
 from qme.main.database.base import Database
 from qme.main.executor import get_named_executor
-from qme.logger import bot
 from glob import glob
+import logging
 import shutil
 import uuid
 import os
 import re
 import sys
+
+bot = logging.getLogger("qme.main.database.filesystem")
 
 
 class FileSystemDatabase(Database):

--- a/qme/main/database/models.py
+++ b/qme/main/database/models.py
@@ -8,7 +8,6 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-from qme.logger import bot
 import json
 import sys
 

--- a/qme/main/database/relational.py
+++ b/qme/main/database/relational.py
@@ -10,15 +10,17 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from qme.main.database.base import Database
 from qme.main.executor import get_named_executor
-from qme.logger import bot
 
 from sqlalchemy import create_engine, desc
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy import and_, or_, not_
 
+import logging
 import os
 import json
 import sys
+
+bot = logging.getLogger("qme.main.database.relational")
 
 
 class RelationalDatabase(Database):

--- a/qme/main/database/sqlite.py
+++ b/qme/main/database/sqlite.py
@@ -9,8 +9,12 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
 
 from qme.main.database.relational import RelationalDatabase
-from qme.logger import bot
+
+import logging
 import os
+import sys
+
+bot = logging.getLogger("qme.main.database.sqlite")
 
 
 class SqliteDatabase(RelationalDatabase):
@@ -30,9 +34,10 @@ class SqliteDatabase(RelationalDatabase):
         # Derive database path, use default of qme.db if not provided
         db_path = os.path.join(config_dir, database_file)
         if not db_path.endswith(".db"):
-            bot.exit(
+            bot.error(
                 f"Invalid database file for sqlite, {database_file} does not end in .db"
             )
+            sys.exit(1)
 
         self.config = config
         self.db = "sqlite:///%s" % db_path

--- a/qme/main/executor/slurm.py
+++ b/qme/main/executor/slurm.py
@@ -8,13 +8,15 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
+import logging
 import os
 import sys
 import re
 
 from qme.utils.file import read_file
-from qme.logger import bot
 from .shell import ShellExecutor
+
+bot = logging.getLogger("qme.main.executor.slurm")
 
 
 class SlurmExecutor(ShellExecutor):
@@ -49,7 +51,8 @@ class SlurmExecutor(ShellExecutor):
             # Find the job id, and any --out or --error files
             match = re.search("[0-9]+", self.data["output"][0])
             if not match:
-                bot.exit(f"Unable to derive job id from {self.data['output']}")
+                bot.error(f"Unable to derive job id from {self.data['output']}")
+                sys.exit(1)
             self.data["jobid"] = match.group()
 
             # Get output file, or default to $PWD/slurm-<jobid>

--- a/qme/version.py
+++ b/qme/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "qme"


### PR DESCRIPTION
This is a quick PR to update the (general) QueueMe logging messages to use the standard Python logging. The user is able to set via the command line with `--log_level` or via an environment variable, `QME_LOG_LEVEL`. There is documentation about this added.

 - This will close #31 

Signed-off-by: vsoch <vsochat@stanford.edu>