### PR TITLE
Fix (for clear) + slight tune up to overall --help

### DIFF
--- a/qme/client/__init__.py
+++ b/qme/client/__init__.py
@@ -58,7 +58,7 @@ def get_parser():
     subparsers.add_parser("version", help="show software version")
 
     # Configure qme (not written yet, will be written when databases added)
-    config = subparsers.add_parser("config", help="configure qme.")
+    config = subparsers.add_parser("config", help="configure qme")
 
     # Specify a database, if not sqlite must include a complete string
     config.add_argument(
@@ -89,23 +89,23 @@ def get_parser():
     )
 
     execute = subparsers.add_parser(
-        "exec", help="Execute an action for the last task, or a taskid"
+        "exec", help="execute an action for the last task, or a taskid"
     )
     execute.add_argument("actions", nargs="*")
 
     generate = subparsers.add_parser(
         "generate-key",
-        help="generate a key for qme start, should be exported to QME_SERVER_KEY.",
+        help="generate a key for qme start, should be exported to QME_SERVER_KEY",
     )
 
     # List tasks and print to terminal
-    ls = subparsers.add_parser("ls", help="List tasks")
+    ls = subparsers.add_parser("ls", help="list tasks")
     ls.add_argument(
         "executor", help="list one or more executors or taskids.", nargs="*"
     )
 
     # Run a command (gets passed to executor via template)
-    run = subparsers.add_parser("run", help="Run a command.")
+    run = subparsers.add_parser("run", help="run a command")
     run.add_argument(
         "cmd",
         nargs="*",
@@ -113,19 +113,19 @@ def get_parser():
     )
 
     # Rerun a task
-    rerun = subparsers.add_parser("rerun", help="Re-run a particular task.")
+    rerun = subparsers.add_parser("rerun", help="re-run a particular task")
     rerun.add_argument("taskid", nargs="?")
 
     # Start the queueMe dashboard
     search = subparsers.add_parser(
         "search",
-        help="Search for content in a command or metadata (sqlite or relational only).",
+        help="search for content in a command or metadata (sqlite or relational only)",
     )
     search.add_argument("query", nargs="*")
 
     # Start the queueMe dashboard
     start = subparsers.add_parser(
-        "start", help="View the queue web interface (requires Flask)"
+        "start", help="view the queue web interface (requires Flask)"
     )
     start.add_argument(
         "--port",
@@ -151,7 +151,7 @@ def get_parser():
     )
 
     # Print complete metadata for a specific task
-    get = subparsers.add_parser("get", help="Get task")
+    get = subparsers.add_parser("get", help="get task")
     get.add_argument("taskid", help="list taskid to return", nargs="?")
     return parser
 

--- a/qme/client/__init__.py
+++ b/qme/client/__init__.py
@@ -78,7 +78,7 @@ def get_parser():
     )
 
     # Clear an entire executor family, one task, or all tasks
-    clear = subparsers.add_parser("clear", help="Run a command to add to the queue.")
+    clear = subparsers.add_parser("clear", help="clear an executor, taskid, or target")
     clear.add_argument("target", nargs="?")
     clear.add_argument(
         "--force",


### PR DESCRIPTION
Feel free to drop any (all) commits, just spotted that `clear` help string was not correct and formatting was not uniform, so now instead of

```
    version             show software version
    config              configure qme.
    clear               Run a command to add to the queue.
    exec                Execute an action for the last task, or a taskid
    generate-key        generate a key for qme start, should be exported to QME_SERVER_KEY.
    ls                  List tasks
    run                 Run a command.
    rerun               Re-run a particular task.
    search              Search for content in a command or metadata (sqlite or relational only).
    start               View the queue web interface (requires Flask)
    get                 Get task
```
it would become
```
    version             show software version
    config              configure qme
    clear               clear an executor, taskid, or target
    exec                execute an action for the last task, or a taskid
    generate-key        generate a key for qme start, should be exported to QME_SERVER_KEY
    ls                  list tasks
    run                 run a command
    rerun               re-run a particular task
    search              search for content in a command or metadata (sqlite or relational only)
    start               view the queue web interface (requires Flask)
    get                 get task
```
I usually do  not bother with trailing `.` is separation is obvious. And to me those descriptions are continuation of a sentence "By running the COMMAND you" (since description is imperative here).